### PR TITLE
Improve bun compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "build:features": "turbo run build --filter=@starkms/features...",
     "story:features": "turbo run story:build --filter=@starkms/features",
     "dev:extension": "turbowatch extension.turbowatch.ts",
-    "lint": "bunx biome check .",
+    "lint": "bun x biome check .",
     "lint:fix": "bun run lint --write",
     "test:unit": "turbo run test:unit",
     "test:e2e:extension": "turbo run test:e2e --filter=@starkms/extension",
-    "format": "bunx biome check --write --unsafe .",
+    "format": "bun x biome check --write --unsafe .",
     "f": "bun run format",
     "cleanup": "turbo run cleanup && rimraf node_modules .turbo",
     "prepare": "husky install",
-    "preinstall": "bunx only-allow bun"
+    "preinstall": "bun x only-allow bun"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build": "bunx --bun tsc --noEmit && bunx --bun tsup src/index.ts --dts --format esm --silent",
-    "cleanup": "bunx --bun rimraf node_modules dist .turbo"
+    "build": "bun x --bun tsc --noEmit && bun x --bun tsup src/index.ts --dts --format esm --silent",
+    "cleanup": "bun x --bun rimraf node_modules dist .turbo"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -12,9 +12,9 @@
     }
   },
   "scripts": {
-    "build": "bunx --bun tsc --noEmit && bunx --bun tsup",
-    "dev": "bunx --bun tsup --watch",
-    "cleanup": "bunx --bun rimraf node_modules dist .turbo"
+    "build": "bun x --bun tsc --noEmit && bun x --bun tsup",
+    "dev": "bun x --bun tsup --watch",
+    "cleanup": "bun x --bun rimraf node_modules dist .turbo"
   },
   "dependencies": {
     "@starkms/util": "workspace:*",

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -12,11 +12,11 @@
     }
   },
   "scripts": {
-    "build": "bunx --bun tsc --noEmit && bunx --bun tsup",
-    "dev": "bunx --bun tsup --watch",
+    "build": "bun x --bun tsc --noEmit && bun x --bun tsup",
+    "dev": "bun x --bun tsup --watch",
     "test:unit": "bun test",
     "coverage": "bun test --coverage",
-    "cleanup": "bunx --bun rimraf node_modules dist .turbo"
+    "cleanup": "bun x --bun rimraf node_modules dist .turbo"
   },
   "dependencies": {
     "@noble/ciphers": "0.5.3",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -12,10 +12,10 @@
     }
   },
   "scripts": {
-    "build": "bunx --bun tsc --noEmit && bunx --bun tsup",
-    "dev": "bunx --bun tsup --watch",
+    "build": "bun x --bun tsc --noEmit && bun x --bun tsup",
+    "dev": "bun x --bun tsup --watch",
     "test:unit": "bun test",
-    "cleanup": "bunx --bun rimraf node_modules dist .turbo"
+    "cleanup": "bun x --bun rimraf node_modules dist .turbo"
   },
   "dependencies": {
     "bs58check": "4.0.0",


### PR DESCRIPTION
## Summary
- make package scripts use `bun x` instead of `bunx`

## Testing
- `bun x biome --version` *(fails: ConnectionRefused downloading package manifest)*