### PR TITLE
Improve Chaum-Pedersen generator

### DIFF
--- a/packages/crypto/src/elliptic-curve/chaum-pedersen/generators.ts
+++ b/packages/crypto/src/elliptic-curve/chaum-pedersen/generators.ts
@@ -1,70 +1,27 @@
 import { utf8ToBytes } from "@noble/hashes/utils"
-import { num } from "starknet" // Import ec for POINT_AT_INFINITY check
+import { starkCurve } from "@noble/curves/stark"
 import {
   G,
-  POINT_AT_INFINITY, // For sanity check
+  POINT_AT_INFINITY,
   type Point,
-  type Scalar,
-  moduloOrder,
-  poseidonHashScalars, // Use the core Poseidon utility
 } from "../core/curve"
 
-// --- AUDIT WARNING --- START ---
-// The method used below for generating H (h_scalar * G) is explicitly
-// called out by the security audit as a soundness risk if h_scalar is knowable (as it is here).
-// This is because the recommended fix, using `hashToCurve` from `@noble/curves/stark`,
-// failed due to module resolution errors (`Cannot find module '@noble/curves/stark'`).
-//
-// CRITICAL TODO: Resolve the dependency/import issue and replace this implementation
-// with one based on a secure hash-to-curve function where the discrete log
-// log_G(H) is unknown.
-//
-// The code below is a temporary fallback to allow the project to build and test other parts.
-// --- AUDIT WARNING --- END ---
-
 /**
- * [TEMPORARY FALLBACK - See AUDIT WARNING above]
- * Hashes an arbitrary string to a field element < CURVE_ORDER using Poseidon.
- * Note: Poseidon is designed for field elements. Hashing arbitrary bytes might not be its primary design.
- * We convert bytes to bigint for input.
+ * Deterministically derives the secondary generator `H` using the
+ * `hashToCurve` helper from `@noble/curves/stark`. This avoids exposing a
+ * known discrete-log relationship between `G` and `H`.
  */
-function hashDomainToScalarPoseidon(domain: string): Scalar {
-  const domainBytes = utf8ToBytes(domain)
-  // Represent bytes as a single large BigInt - simple method, might not be canonical
-  // Consider padding or specific encoding if needed for stricter domain separation.
-  const domainBigInt = num.toBigInt(
-    `0x${Buffer.from(domainBytes).toString("hex")}`,
-  )
-  // Poseidon hash expects an array
-  const hashedScalar = poseidonHashScalars([domainBigInt])
-  return moduloOrder(hashedScalar) // Ensure result is < CURVE_ORDER
-}
-
-/**
- * [TEMPORARY FALLBACK - See AUDIT WARNING above]
- * Secondary generator H = h * G, where h = PoseidonHash(domain_string_bytes).
- * WARNING: log_G(H) = h, and h is publicly computable.
- */
-const h_scalar_public = hashDomainToScalarPoseidon(
-  "ChaumPedersen.H (v1 fallback)",
+const hashedPoint = starkCurve.ProjectivePoint.hashToCurve(
+  utf8ToBytes("ChaumPedersen.H"),
 )
-if (h_scalar_public === 0n) {
-  // This is unlikely if Poseidon is cryptographically sound.
-  throw new Error(
-    "[Temporary H Gen Fallback] Hash for H resulted in a zero scalar.",
-  )
-}
-export const H: Point = G.multiply(h_scalar_public)
+export const H: Point = hashedPoint
 
-// Sanity check H
+// Sanity checks for the derived generator
 if (H.equals(POINT_AT_INFINITY)) {
-  throw new Error(
-    "[Temporary H Gen Fallback] Derived generator H is the point at infinity.",
-  )
+  throw new Error("Derived generator H is the point at infinity")
 }
 if (H.equals(G)) {
-  // This would happen if hash(...) = 1, extremely unlikely.
   console.warn(
-    "[Temporary H Gen Fallback] Derived generator H is equal to G. Check domain string or hash function.",
+    "Derived generator H unexpectedly equals G. Consider adjusting the domain string.",
   )
 }

--- a/packages/crypto/test/elliptic-curve/generators.test.ts
+++ b/packages/crypto/test/elliptic-curve/generators.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test"
+import { utf8ToBytes } from "@noble/hashes/utils"
+import { starkCurve } from "@noble/curves/stark"
+import { G, H, POINT_AT_INFINITY } from "../../src/elliptic-curve/chaum-pedersen/generators"
+
+// Ensure the exported H matches a fresh hashToCurve computation
+const expectedH = starkCurve.ProjectivePoint.hashToCurve(
+  utf8ToBytes("ChaumPedersen.H"),
+)
+
+describe("Chaum-Pedersen generators", () => {
+  it("derives H deterministically via hashToCurve", () => {
+    expect(H.equals(expectedH)).toBe(true)
+  })
+
+  it("H is a valid generator distinct from G and infinity", () => {
+    expect(H.equals(POINT_AT_INFINITY)).toBe(false)
+    expect(H.equals(G)).toBe(false)
+  })
+})

--- a/packages/crypto/test/elliptic-curve/transcript.test.ts
+++ b/packages/crypto/test/elliptic-curve/transcript.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test"
+import { generateChallenge, serializePointForTranscript } from "../../src/elliptic-curve/chaum-pedersen/transcript"
+import { G, H } from "../../src/elliptic-curve/chaum-pedersen"
+
+
+// Deterministic challenge for fixed inputs
+const P = G.multiply(1n)
+const Q = H.multiply(1n)
+const U = G.multiply(2n)
+const V = H.multiply(2n)
+const expected = generateChallenge(P, Q, U, V)
+
+describe("Chaum-Pedersen transcript", () => {
+  it("serializePointForTranscript returns x and y parity", () => {
+    const [x, parity] = serializePointForTranscript(P)
+    expect(x).toBe(P.toAffine().x)
+    expect(parity === 0n || parity === 1n).toBe(true)
+  })
+
+  it("generateChallenge is deterministic", () => {
+    const c1 = generateChallenge(P, Q, U, V)
+    const c2 = generateChallenge(P, Q, U, V)
+    expect(c1).toBe(c2)
+    expect(typeof c1).toBe("bigint")
+  })
+
+  it("challenge changes when inputs change", () => {
+    const alt = generateChallenge(P, Q, G.multiply(3n), V)
+    expect(alt).not.toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary
- use `hashToCurve` when deriving `H`
- document the secure generator derivation
- add regression tests for generator and transcript helpers

## Security Impact
- removes the known discrete-log relation between `G` and `H`

## Testing
- `bun run ci` *(fails: cannot find module '@noble/hashes/utils', etc.)*
- `bun test` in `packages/crypto` *(fails: missing dependencies)*